### PR TITLE
Drop blockers from x11-themes/gnome-icon-theme-symbolic

### DIFF
--- a/x11-themes/gnome-icon-theme-symbolic/gnome-icon-theme-symbolic-3.10.0.ebuild
+++ b/x11-themes/gnome-icon-theme-symbolic/gnome-icon-theme-symbolic-3.10.0.ebuild
@@ -17,10 +17,8 @@ KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-
 
 COMMON_DEPEND=">=x11-themes/hicolor-icon-theme-0.10"
 
-RDEPEND="${COMMON_DEPEND}
-	!=gnome-extra/gnome-power-manager-3.0*
-	!=gnome-extra/gnome-power-manager-3.1*
-"
+RDEPEND="${COMMON_DEPEND}"
+
 # keyboard-brightness icon file collision with old gnome-power-manager
 DEPEND="${COMMON_DEPEND}
 	>=x11-misc/icon-naming-utils-0.8.7


### PR DESCRIPTION
Fixes #7 in Heather/gentoo-gnome

gnome-icon-theme-symbolic had blockers on gnome-power-manager-3.0\* and
gnome-power-manager-3.1*. None of this stuff is in the tree any more,
and the latter blocker is clashing with gnome-power-manager-3.10.
