### PR TITLE
=gnome-base/gnome-settings-daemon-3.10.1 misses mandatory colord dependency

### DIFF
--- a/gnome-base/gnome-settings-daemon/gnome-settings-daemon-3.10.1.ebuild
+++ b/gnome-base/gnome-settings-daemon/gnome-settings-daemon-3.10.1.ebuild
@@ -15,7 +15,9 @@ LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~x86 ~x86-fbsd ~x86-freebsd ~amd64-linux ~x86-linux ~x86-solaris"
 
-IUSE="+colord +cups debug +i18n packagekit policykit +short-touchpad-timeout smartcard +udev"
+IUSE="+cups debug +i18n packagekit policykit +short-touchpad-timeout smartcard +udev"
+# TODO: ^ Add +colord back when it is made optional.
+
 REQUIRED_USE="
 	packagekit? ( udev )
 	smartcard? ( udev )
@@ -52,13 +54,15 @@ COMMON_DEPEND="
 	>=sci-geosciences/geocode-glib-0.99.3
 	>=app-misc/geoclue-1.99.4:2
 
-	colord? ( >=x11-misc/colord-1.0.2:= )
+	>=x11-misc/colord-1.0.2:=
 	cups? ( >=net-print/cups-1.4[dbus] )
 	i18n? ( >=app-i18n/ibus-1.4.99 )
 	packagekit? ( >=app-admin/packagekit-base-0.8.1 )
 	smartcard? ( >=dev-libs/nss-3.11.2 )
 	udev? ( virtual/udev[gudev] )
 "
+# TODO: ^ Surround colord with USE flag condition once it is made back optional.
+
 # Themes needed by g-s-d, gnome-shell, gtk+:3 apps to work properly
 # <gnome-color-manager-3.1.1 has file collisions with g-s-d-3.1.x
 # <gnome-power-manager-3.1.3 has file collisions with g-s-d-3.1.x
@@ -108,7 +112,6 @@ src_configure() {
 	gnome2_src_configure \
 		--disable-static \
 		--enable-man \
-		$(use_enable colord color) \
 		$(use_enable cups) \
 		$(use_enable debug) \
 		$(use_enable debug more-warnings) \
@@ -116,6 +119,7 @@ src_configure() {
 		$(use_enable packagekit) \
 		$(use_enable smartcard smartcard-support) \
 		$(use_enable udev gudev) 
+# TODO: $(use_enable colord color) \
 
 		#FIXME: Maybe with patch it will be possible
 		#$(use_enable input_devices_wacom wacom)

--- a/gnome-base/gnome-settings-daemon/gnome-settings-daemon-9999.ebuild
+++ b/gnome-base/gnome-settings-daemon/gnome-settings-daemon-9999.ebuild
@@ -16,7 +16,8 @@ HOMEPAGE="http://www.gnome.org"
 
 LICENSE="GPL-2+"
 SLOT="0"
-IUSE="+colord +cups debug +i18n input_devices_wacom packagekit policykit +short-touchpad-timeout smartcard systemd +udev"
+IUSE="+cups debug +i18n input_devices_wacom packagekit policykit +short-touchpad-timeout smartcard systemd +udev"
+# TODO: ^ Add +colord back when it is made optional.
 if [[ ${PV} = 9999 ]]; then
 	KEYWORDS=""
 else
@@ -50,7 +51,7 @@ COMMON_DEPEND="
 	x11-libs/libXtst
 	x11-libs/libXxf86misc
 
-	colord? ( >=x11-misc/colord-0.1.27:= )
+	>=x11-misc/colord-0.1.27:=
 	cups? ( >=net-print/cups-1.4[dbus] )
 	i18n? ( >=app-i18n/ibus-1.4.99 )
 	input_devices_wacom? (
@@ -61,6 +62,8 @@ COMMON_DEPEND="
 	systemd? ( >=sys-apps/systemd-31 )
 	udev? ( virtual/udev[gudev] )
 "
+# TODO: ^ Surround colord with USE flag condition once it is made back optional.
+
 # Themes needed by g-s-d, gnome-shell, gtk+:3 apps to work properly
 # <gnome-color-manager-3.1.1 has file collisions with g-s-d-3.1.x
 # <gnome-power-manager-3.1.3 has file collisions with g-s-d-3.1.x
@@ -109,7 +112,6 @@ src_configure() {
 	gnome2_src_configure \
 		--disable-static \
 		--enable-man \
-		$(use_enable colord color) \
 		$(use_enable cups) \
 		$(use_enable debug) \
 		$(use_enable debug more-warnings) \
@@ -119,6 +121,7 @@ src_configure() {
 		$(use_enable systemd) \
 		$(use_enable udev gudev) \
 		$(use_enable input_devices_wacom wacom)
+# TODO: $(use_enable colord color) \
 }
 
 src_test() {


### PR DESCRIPTION
Build log output:

```
configure: error: Package requirements (colord >= 1.0.2 gnome-desktop-3.0 >= 3.9.0 libcanberra-gtk3) were not met:

No package 'colord' found
```

Earlier output indicates:

```
configure: WARNING: unrecognized options: --disable-color
```

Seems this became a hard dependency instead of optional.

Ah, I see you had a patch; eh well, this is now a tracking to make it optional again.

Submitting a commit to temporarily make it mandatory:
