### PR TITLE
Rename repository "gnome" to "gnome-next".

### DIFF
--- a/profiles/repo_name
+++ b/profiles/repo_name
@@ -1,1 +1,1 @@
-gnome
+gnome-next


### PR DESCRIPTION
This clarifies which repository this is as to not confuse it with the official overlay.
