### PR TITLE
gnome-shell unrecognized configure option --disable-jhbuild-wrapper-script

### DIFF
--- a/gnome-base/gnome-shell/gnome-shell-3.10.1.ebuild
+++ b/gnome-base/gnome-shell/gnome-shell-3.10.1.ebuild
@@ -131,7 +131,6 @@ src_configure() {
 	# Do not error out on warnings
 	gnome2_src_configure \
 		--enable-man \
-		--disable-jhbuild-wrapper-script \
 		BROWSER_PLUGIN_DIR="${EPREFIX}"/usr/$(get_libdir)/nsbrowser/plugins
 }
 


### PR DESCRIPTION
```
QA Notice: Unrecognized configure options:
    --disable-jhbuild-wrapper-script
```
