### PR TITLE
dev-libs/folks: Backport patches fixing crash in 0.9.6

### DIFF
--- a/dev-libs/folks/files/folks-0.9.6-fix-individual.patch
+++ b/dev-libs/folks/files/folks-0.9.6-fix-individual.patch
@@ -1,0 +1,80 @@
+From e60e48ddc902e4f7c87370362e87cd5760f888d2 Mon Sep 17 00:00:00 2001
+From: Philip Withnall <philip.withnall@collabora.co.uk>
+Date: Wed, 20 Nov 2013 11:55:05 +0000
+Subject: [PATCH] Fix crash of empathy
+
+See: https://bugzilla.redhat.com/show_bug.cgi?id=1031252
+---
+ folks/individual.vala | 42 +++++++++++++++++++++++++++++++++++++++---
+ 1 file changed, 39 insertions(+), 3 deletions(-)
+
+diff --git a/folks/individual.vala b/folks/individual.vala
+index 06cae99..ab1b034 100644
+--- a/folks/individual.vala
++++ b/folks/individual.vala
+@@ -1205,14 +1205,41 @@ public class Folks.Individual : Object,
+ 
+   private void _persona_notify_cb (Object obj, ParamSpec ps)
+     {
+-      assert (obj is Persona);
+-      assert (ps.name == "individual" || (obj as Persona).individual == this);
++      var persona = (Persona) obj;  /* will abort on failure */
++
++      /* It should not be possible for two Individuals to be simultaneously
++       * connected to the same Persona (as _connect_to_persona() will disconnect
++       * any previous Persona.individual), but warn (rather than asserting) just
++       * in case, since this is a critical code path. */
++      if (ps.name != "individual" &&
++          persona.individual != this &&
++          persona.individual != null)
++        {
++          warning ("Notification on property ‘%s’ of Persona %p (‘%s’) where " +
++              "Persona.individual is %p but was expected to be %p.",
++              ps.name, persona, persona.uid, persona.individual, this);
++          return;
++        }
++      else if (ps.name == "individual")
++        {
++          if (persona.individual != this)
++            {
++              /* Remove the notified persona from our set of personas. */
++              var remaining_personas = new SmallSet<Persona> ();
++              remaining_personas.add_all (this._persona_set);
++              remaining_personas.remove (persona);
++
++              this._set_personas (remaining_personas, null);
++            }
++
++          return;
++        }
+ 
+       foreach (var notifier in Individual._notifiers)
+         {
+           if (ps.name == notifier.property)
+             {
+-              notifier.notify (this, (!) (obj as Persona), ps);
++              notifier.notify (this, persona, ps);
+               break;  /* assume all entries in notifiers are unique */
+             }
+         }
+@@ -1886,8 +1913,17 @@ public class Folks.Individual : Object,
+             }, emit_notification, force_update);
+     }
+ 
++  /* Note: This causes the Persona to be stolen away from its current
++   * Individual. */
+   private void _connect_to_persona (Persona persona)
+     {
++      if (persona.individual != null && persona.individual != this)
++        {
++          /* Disconnect the previous Individual. This atomically avoids having
++           * two Individuals connected to the same Persona simultaneously. */
++          persona.individual._disconnect_from_persona (persona, this);
++        }
++
+       persona.individual = this;
+ 
+       /* We're interested in most, if not all, signals from a persona,
+-- 
+1.8.5.2
+

--- a/dev-libs/folks/folks-0.9.6.ebuild
+++ b/dev-libs/folks/folks-0.9.6.ebuild
@@ -55,6 +55,8 @@ src_prepare() {
 	# Regenerate C files until folks-0.9.4 lands the tree, bug #479600
 	touch backends/telepathy/lib/tpf-persona.vala || die
 
+	epatch "${FILESDIR}/${P}-fix-individual.patch"
+
 	vala_src_prepare
 	gnome2_src_prepare
 }


### PR DESCRIPTION
[Upstream bug](https://bugzilla.gnome.org/show_bug.cgi?id=720865)
