### PR TITLE
net-im/telepathy-mission-control: Newer versions of upower breaks build.

### DIFF
--- a/net-im/telepathy-mission-control/telepathy-mission-control-5.16.1.ebuild
+++ b/net-im/telepathy-mission-control/telepathy-mission-control-5.16.1.ebuild
@@ -28,8 +28,7 @@ RDEPEND="
 	>=net-libs/telepathy-glib-0.23.0
 	connman? ( net-misc/connman )
 	networkmanager? ( >=net-misc/networkmanager-0.7 )
-	upower? ( >=sys-power/upower-0.9.11
-		  >=sys-power/upower-0.99 )
+	upower? ( >=sys-power/upower-0.9.11 <sys-power/upower-0.99 )
 "
 DEPEND="${RDEPEND}
 	${PYTHON_DEPS}


### PR DESCRIPTION
Not 100% sure this is how to do it, but upower version must be smaller than 0.99.
