### PR TITLE
x11-libs/gtk+-3.22.0: Bump EAPI to 6

### DIFF
--- a/x11-libs/gtk+/gtk+-3.22.0.ebuild
+++ b/x11-libs/gtk+/gtk+-3.22.0.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
+EAPI=6
 GNOME2_LA_PUNT="yes"
 
 inherit autotools eutils flag-o-matic gnome2 multilib virtualx multilib-minimal


### PR DESCRIPTION
The ebuild uses eapply, which was added in EAPI 6. Using EAPI 5 prevents gtk+-3.16.2-remove_update-icon-cache.patch from being applied, which creates a file collision if gtk2 is also installed.