### PR TITLE
[gnome-desktop] 3.24 dependency requirements

### DIFF
--- a/gnome-base/gnome-desktop/gnome-desktop-3.24.0.ebuild
+++ b/gnome-base/gnome-desktop/gnome-desktop-3.24.0.ebuild
@@ -17,7 +17,7 @@ KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sh ~sparc ~x86 ~x86-fbsd ~
 COMMON_DEPEND="
 	app-text/iso-codes
 	>=dev-libs/glib-2.44.0:2[dbus]
-	>=x11-libs/gdk-pixbuf-2.33.0:2[introspection?]
+	>=x11-libs/gdk-pixbuf-2.36.5:2[introspection?]
 	>=x11-libs/gtk+-3.3.6:3[X,introspection?]
 	x11-libs/cairo:=[X]
 	x11-libs/libX11


### PR DESCRIPTION
Fails to configure/build if gdk-pixbuf is below 2.36.5