### PR TITLE
[gnome-base/nautilus] 3.24 dependency update

### DIFF
--- a/gnome-base/nautilus/nautilus-3.24.0.ebuild
+++ b/gnome-base/nautilus/nautilus-3.24.0.ebuild
@@ -24,8 +24,8 @@ RESTRICT="test"
 # Require {glib,gdbus-codegen}-2.30.0 due to GDBus API changes between 2.29.92
 # and 2.30.0
 COMMON_DEPEND="
-	>=app-arch/gnome-autoar-0.1
-	>=dev-libs/glib-2.49.1:2[dbus]
+	>=app-arch/gnome-autoar-0.2.1
+	>=dev-libs/glib-2.51.2:2[dbus]
 	>=x11-libs/pango-1.28.3
 	>=x11-libs/gtk+-3.21.6:3[introspection?]
 	>=dev-libs/libxml2-2.7.8:2


### PR DESCRIPTION
Fails to configure/build without updated dependencies ( `app-arch/gnome-autoar` `dev-libs/glib` )