### PR TITLE
Add CFLAGS -std=gnu11 in ebuild

### DIFF
--- a/gnome-base/gnome-control-center/gnome-control-center-3.24.0.ebuild
+++ b/gnome-base/gnome-control-center/gnome-control-center-3.24.0.ebuild
@@ -14,6 +14,7 @@ LICENSE="GPL-2+"
 SLOT="2"
 IUSE="+bluetooth +colord debug +gnome-online-accounts +i18n input_devices_wacom kerberos networkmanager v4l wayland"
 KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sh ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~x86-solaris"
+CFLAGS="${CFLAGS} -std=gnu11"
 
 # False positives caused by nested configure scripts
 QA_CONFIGURE_OPTIONS=".*"

--- a/gnome-base/libgtop/libgtop-2.36.0.ebuild
+++ b/gnome-base/libgtop/libgtop-2.36.0.ebuild
@@ -11,6 +11,7 @@ LICENSE="GPL-2"
 SLOT="2/10" # libgtop soname version
 KEYWORDS="alpha amd64 arm ia64 ~mips ppc ppc64 ~sh sparc x86 ~x86-fbsd"
 IUSE="+introspection"
+CFLAGS="${CFLAGS} -std=gnu11"
 
 RDEPEND="
 	>=dev-libs/glib-2.26:2


### PR DESCRIPTION
I don't actually know if this is the correct method for doing this, however this is the way I have succeeded in getting these two packages to compile. Without this, it fails with a message about assignment before a for loop not being allowed and suggests changing `-std` to C99 or C11 (or gnu variants).

(Also there's no change in the Manifests when I do this for whatever reason.)