### PR TITLE
tracker: Add sys-libs/libseccomp to RDEPEND

### DIFF
--- a/app-misc/tracker/tracker-1.12.0.ebuild
+++ b/app-misc/tracker/tracker-1.12.0.ebuild
@@ -13,9 +13,10 @@ HOMEPAGE="https://wiki.gnome.org/Projects/Tracker"
 
 LICENSE="GPL-2+ LGPL-2.1+"
 SLOT="0/100"
-IUSE="cue elibc_glibc exif ffmpeg firefox-bookmarks flac gif gsf
-gstreamer gtk iptc +iso +jpeg libav +miner-fs mp3 nautilus networkmanager
-pdf playlist rss stemmer test thunderbird +tiff upnp-av upower +vorbis +xml xmp xps"
+IUSE="cue elibc_glibc exif ffmpeg firefox-bookmarks flac gif gsf gstreamer gtk
+iptc +iso +jpeg kernel_linux libav +miner-fs mp3 nautilus networkmanager pdf
+playlist rss stemmer test thunderbird +tiff upnp-av upower +vorbis +xml xmp
+xps"
 
 KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc ~x86"
 
@@ -62,6 +63,7 @@ RDEPEND="
 	iptc? ( media-libs/libiptcdata )
 	iso? ( >=sys-libs/libosinfo-0.2.9:= )
 	jpeg? ( virtual/jpeg:0 )
+	kernel_linux? ( >=sys-libs/libseccomp-2.0.0 )
 	upower? ( || ( >=sys-power/upower-0.9 sys-power/upower-pm-utils ) )
 	mp3? ( >=media-libs/taglib-1.6 )
 	networkmanager? ( >=net-misc/networkmanager-0.8:= )


### PR DESCRIPTION
seccomp is now mandatory on Linux.

https://git.gnome.org/browse/tracker/commit/?id=397e1e00c455babaa1d6e65f04e1f7145020731e
https://git.gnome.org/browse/tracker/commit/?id=bdf25c78ee11e25bf017e37c78f7c07a2f7ac29a