### PR TITLE
[www-client/epiphany] CFLAGS append gnu11

### DIFF
--- a/www-client/epiphany/epiphany-3.24.1.ebuild
+++ b/www-client/epiphany/epiphany-3.24.1.ebuild
@@ -13,6 +13,7 @@ LICENSE="GPL-2"
 SLOT="0"
 IUSE="test"
 KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~sparc ~x86"
+CFLAGS="${CFLAGS} -std=gnu11"
 
 COMMON_DEPEND="
 	>=app-crypt/gcr-3.5.5:=


### PR DESCRIPTION
Does not build (for me) without adjusting -std

```
ephy-filters-manager.c: In function ‘remove_old_adblock_filters’:
ephy-filters-manager.c:207:5: error: ‘for’ loop initial declarations are only allowed in C99 or C11 mode
     for (GList *l = current_files; l != NULL; l = l->next) {
     ^
ephy-filters-manager.c:207:5: note: use option -std=c99, -std=gnu99, -std=c11 or -std=gnu11 to compile your code
ephy-filters-manager.c: In function ‘update_adblock_filter_files’:
ephy-filters-manager.c:244:3: error: ‘for’ loop initial declarations are only allowed in C99 or C11 mode
   for (guint i = 0; filters[i]; i++) {
   ^
make[4]: *** [Makefile:801: libephymisc_la-ephy-filters-manager.lo] Error 1
```
```
$ gcc --version
gcc (Gentoo 4.9.4 p1.0, pie-0.6.4) 4.9.4
```