### PR TITLE
Alter CFLAGS of some packages to build with <gcc-5

### DIFF
--- a/gnome-base/gnome-control-center/gnome-control-center-3.24.1.ebuild
+++ b/gnome-base/gnome-control-center/gnome-control-center-3.24.1.ebuild
@@ -5,7 +5,7 @@
 EAPI=6
 GNOME2_LA_PUNT="yes"
 
-inherit autotools bash-completion-r1 gnome2
+inherit autotools bash-completion-r1 gnome2 flag-o-matic
 
 DESCRIPTION="GNOME's main interface to configure various aspects of the desktop"
 HOMEPAGE="https://git.gnome.org/browse/gnome-control-center/"
@@ -14,7 +14,6 @@ LICENSE="GPL-2+"
 SLOT="2"
 IUSE="+bluetooth +colord debug +gnome-online-accounts +i18n input_devices_wacom kerberos networkmanager v4l wayland"
 KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sh ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~x86-solaris"
-CFLAGS="${CFLAGS} -std=gnu11"
 
 # False positives caused by nested configure scripts
 QA_CONFIGURE_OPTIONS=".*"
@@ -125,6 +124,8 @@ DEPEND="${COMMON_DEPEND}
 #	sys-devel/autoconf-archive
 
 src_prepare() {
+	append-cflags -std=gnu11
+
 	# Make some panels and dependencies optional; requires eautoreconf
 	# https://bugzilla.gnome.org/686840, 697478, 700145
 	eapply "${FILESDIR}"/${PN}-3.23.90-optional.patch

--- a/gnome-base/libgtop/libgtop-2.36.0.ebuild
+++ b/gnome-base/libgtop/libgtop-2.36.0.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit gnome2
+inherit gnome2 flag-o-matic
 
 DESCRIPTION="A library that provides top functionality to applications"
 HOMEPAGE="https://git.gnome.org/browse/libgtop"
@@ -11,7 +11,6 @@ LICENSE="GPL-2"
 SLOT="2/10" # libgtop soname version
 KEYWORDS="alpha amd64 arm ia64 ~mips ppc ppc64 ~sh sparc x86 ~x86-fbsd"
 IUSE="+introspection"
-CFLAGS="${CFLAGS} -std=gnu11"
 
 RDEPEND="
 	>=dev-libs/glib-2.26:2
@@ -22,6 +21,11 @@ DEPEND="${RDEPEND}
 	>=sys-devel/gettext-0.19.4
 	virtual/pkgconfig
 "
+
+src_prepare() {
+	append-cflags -std=gnu11
+	default
+}
 
 src_configure() {
 	gnome2_src_configure \

--- a/www-client/epiphany/epiphany-3.24.1.ebuild
+++ b/www-client/epiphany/epiphany-3.24.1.ebuild
@@ -4,7 +4,7 @@
 EAPI=6
 GNOME2_LA_PUNT="yes"
 
-inherit eutils gnome2 virtualx
+inherit eutils gnome2 virtualx flag-o-matic
 
 DESCRIPTION="GNOME webbrowser based on Webkit"
 HOMEPAGE="https://wiki.gnome.org/Apps/Web"
@@ -54,6 +54,11 @@ PATCHES=(
 	# https://bugzilla.gnome.org/show_bug.cgi?id=751593
 	"${FILESDIR}"/${PN}-3.14.0-unittest-2.patch
 )
+
+src_prepare() {
+	# https://bugzilla.gnome.org/show_bug.cgi?id=778495
+	append-cflags -std=gnu11
+}
 
 src_configure() {
 	gnome2_src_configure \


### PR DESCRIPTION
- Adds `-std=gnu11` to `www-client/epiphany`
```ephy-filters-manager.c: In function ‘remove_old_adblock_filters’:
ephy-filters-manager.c:207:5: error: ‘for’ loop initial declarations are only allowed in C99 or C11 mode
     for (GList *l = current_files; l != NULL; l = l->next) {
     ^
ephy-filters-manager.c:207:5: note: use option -std=c99, -std=gnu99, -std=c11 or -std=gnu11 to compile your code
ephy-filters-manager.c: In function ‘update_adblock_filter_files’:
ephy-filters-manager.c:244:3: error: ‘for’ loop initial declarations are only allowed in C99 or C11 mode
   for (guint i = 0; filters[i]; i++) {
   ^
make[4]: *** [Makefile:801: libephymisc_la-ephy-filters-manager.lo] Error 1
```
```
$ gcc --version
gcc (Gentoo 4.9.4 p1.0, pie-0.6.4) 4.9.4
```
- Changes other packages (`gnome-control-center`, `libgtop`) to use `append-cflags` instead of a variable according to this suggestion: https://github.com/Heather/gentoo-gnome/pull/173#discussion_r111707745