### PR TITLE
Revert cflags

### DIFF
--- a/gnome-base/gnome-control-center/gnome-control-center-3.24.1.ebuild
+++ b/gnome-base/gnome-control-center/gnome-control-center-3.24.1.ebuild
@@ -5,7 +5,7 @@
 EAPI=6
 GNOME2_LA_PUNT="yes"
 
-inherit autotools bash-completion-r1 gnome2 flag-o-matic
+inherit autotools bash-completion-r1 gnome2
 
 DESCRIPTION="GNOME's main interface to configure various aspects of the desktop"
 HOMEPAGE="https://git.gnome.org/browse/gnome-control-center/"
@@ -124,8 +124,6 @@ DEPEND="${COMMON_DEPEND}
 #	sys-devel/autoconf-archive
 
 src_prepare() {
-	append-cflags -std=gnu11
-
 	# Make some panels and dependencies optional; requires eautoreconf
 	# https://bugzilla.gnome.org/686840, 697478, 700145
 	eapply "${FILESDIR}"/${PN}-3.23.90-optional.patch

--- a/gnome-base/libgtop/libgtop-2.36.0.ebuild
+++ b/gnome-base/libgtop/libgtop-2.36.0.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit gnome2 flag-o-matic
+inherit gnome2
 
 DESCRIPTION="A library that provides top functionality to applications"
 HOMEPAGE="https://git.gnome.org/browse/libgtop"
@@ -21,11 +21,6 @@ DEPEND="${RDEPEND}
 	>=sys-devel/gettext-0.19.4
 	virtual/pkgconfig
 "
-
-src_prepare() {
-	append-cflags -std=gnu11
-	default
-}
 
 src_configure() {
 	gnome2_src_configure \

--- a/www-client/epiphany/epiphany-3.25.1.ebuild
+++ b/www-client/epiphany/epiphany-3.25.1.ebuild
@@ -4,7 +4,7 @@
 EAPI=6
 GNOME2_LA_PUNT="yes"
 
-inherit eutils gnome2 virtualx flag-o-matic multiprocessing
+inherit eutils gnome2 virtualx multiprocessing
 
 DESCRIPTION="GNOME webbrowser based on Webkit"
 HOMEPAGE="https://wiki.gnome.org/Apps/Web"
@@ -59,8 +59,6 @@ PATCHES=(
 MESON_BUILD_DIR="${WORKDIR}/${P}_mesonbuild"
 
 src_prepare() {
-	# https://bugzilla.gnome.org/show_bug.cgi?id=778495
-	append-cflags -std=gnu11
 	mkdir -p "${MESON_BUILD_DIR}" || die
 	default
 }


### PR DESCRIPTION
GCC v5 has been stablized in the gentoo tree, making CFLAG adjustments unnecessary.