### PR TITLE
[dev-libs/gmime] v3.0.0 slot change (2.6 -> 3.0)

### DIFF
--- a/dev-libs/gmime/gmime-3.0.0.ebuild
+++ b/dev-libs/gmime/gmime-3.0.0.ebuild
@@ -9,7 +9,7 @@ inherit mono-env gnome2 vala
 DESCRIPTION="Utilities for creating and parsing messages using MIME"
 HOMEPAGE="http://spruce.sourceforge.net/gmime/ https://developer.gnome.org/gmime/stable/"
 
-SLOT="2.6"
+SLOT="3.0"
 LICENSE="LGPL-2.1"
 KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
 IUSE="doc mono smime static-libs test vala"


### PR DESCRIPTION
Packages such as `dev-libs/totem-pl-parser-3.10.7` require gmime-2.6; but because this overlay puts v3.0.0 into the 2.6 slot, the package is upgraded. The totem package's DEPENDS allow 3.0 to be installed, and so when it is being built it fails.

~~I don't know if changing the slot of gmime is the correct solution (obviously the totem package's dependencies are not specific enough), but~~ does it make sense for gmime v3.0.0 to be in a 3.0 slot since the package does already have slots for its versions? I have both versions installed currently, and so far nothing has exploded.