### PR TITLE
[networkmananger] 1.8.0 unstabilize for build issues

### DIFF
--- a/net-misc/networkmanager/networkmanager-1.8.0-r1.ebuild
+++ b/net-misc/networkmanager/networkmanager-1.8.0-r1.ebuild
@@ -30,7 +30,7 @@ REQUIRED_USE="
 
 #~alpha amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~sparc x86
 #make all-am needs fixing
-KEYWORDS="~alpha amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~sparc x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
 
 # gobject-introspection-0.10.3 is needed due to gnome bug 642300
 # wpa_supplicant-0.7.3-r3 is needed due to bug 359271


### PR DESCRIPTION
Please confirm whether this issue exists for anyone besides me?

---

Many file require `nm-core-enum-types.h`, however this file does not exist during build.

```
$ emerge ....
....
x86_64-pc-linux-gnu-gcc -m32 -DHAVE_CONFIG_H -I. -I/var/tmp/portage/net-misc/networkmanager-1.8.0/work/NetworkManager-1.8.0  -pthread -I/usr/include/gio-unix-2.0/ -I/usr/include/glib-2.0 -I/usr/lib32/glib-2.0/include  -DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_32 -DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_32 -I/var/tmp/portage/net-misc/networkmanager-1.8.0/work/NetworkManager-1.8.0/shared -I./shared -I/var/tmp/portage/net-misc/networkmanager-1.8.0/work/NetworkManager-1.8.0/libnm-core -I./libnm-core -DG_LOG_DOMAIN=\""nm-dhcp-helper"\" -DNMRUNDIR=\"/run/NetworkManager\"   -fdata-sections -ffunction-sections -Wl,--gc-sections -march=native -O2 -pipe  -fno-strict-aliasing -MT src/dhcp/src_dhcp_nm_dhcp_helper-nm-dhcp-helper.o -MD -MP -MF src/dhcp/.deps/src_dhcp_nm_dhcp_helper-nm-dhcp-helper.Tpo -c -o src/dhcp/src_dhcp_nm_dhcp_helper-nm-dhcp-helper.o `test -f 'src/dhcp/nm-dhcp-helper.c' || echo '/var/tmp/portage/net-misc/networkmanager-1.8.0/work/NetworkManager-1.8.0/'`src/dhcp/nm-dhcp-helper.c
In file included from /var/tmp/portage/net-misc/networkmanager-1.8.0/work/NetworkManager-1.8.0/src/nm-logging.h:25:0,
                 from /var/tmp/portage/net-misc/networkmanager-1.8.0/work/NetworkManager-1.8.0/shared/nm-default.h:203,
                 from /var/tmp/portage/net-misc/networkmanager-1.8.0/work/NetworkManager-1.8.0/src/settings/plugins/ifnet/nms-ifnet-connection.c:22:
/var/tmp/portage/net-misc/networkmanager-1.8.0/work/NetworkManager-1.8.0/libnm-core/nm-core-types.h:28:32: fatal error: nm-core-enum-types.h: No such file or directory
compilation terminated.
make: *** [Makefile:12971: src/settings/plugins/ifnet/src_settings_plugins_ifnet_libnm_settings_plugin_ifnet_la-nms-ifnet-connection.lo] Error 1
....
```

```
/v/t/p/n/n/w/NetworkManager-1.8.0$ rg nm-core-enum-types.h
Makefile.in
4175:	libnm-core/nm-core-enum-types.h
4406:nm_enum_types_MKENUMS_H_FLAGS = --identifier-prefix NM --fhead '\#include <nm-core-enum-types.h>\n'
16971:libnm-core/nm-core-enum-types.h.stamp:                                      libnm-core/.dirstamp

Makefile.am
415:	libnm-core/nm-core-enum-types.h
522:libnm-core/nm-core-enum-types.h.stamp:                                      libnm-core/.dirstamp
811:nm_enum_types_MKENUMS_H_FLAGS = --identifier-prefix NM --fhead '\#include <nm-core-enum-types.h>\n'

libnm-core/nm-setting-cdma.c
29:#include "nm-core-enum-types.h"

libnm-core/nm-setting-gsm.c
30:#include "nm-core-enum-types.h"

libnm-core/nm-setting-adsl.c
30:#include "nm-core-enum-types.h"

libnm-core/nm-setting-8021x.c
33:#include "nm-core-enum-types.h"

libnm-core/nm-setting-pppoe.c
30:#include "nm-core-enum-types.h"

libnm-core/nm-core-types.h
28:#include "nm-core-enum-types.h"

libnm-core/nm-setting-private.h
26:#include "nm-core-enum-types.h"

libnm-core/nm-setting-ip6-config.c
30:#include "nm-core-enum-types.h"

libnm-core/nm-core-internal.h
38:#include "nm-core-enum-types.h"

libnm-core/nm-utils.h
36:#include "nm-core-enum-types.h"

libnm-core/nm-setting-dcb.c
30:#include "nm-core-enum-types.h"

libnm-core/nm-setting-connection.c
31:#include "nm-core-enum-types.h"

libnm/NetworkManager.h
30:#include "nm-core-enum-types.h"
```

```
/v/t/p/n/n/w/NetworkManager-1.8.0$ find . -type f -name nm-core-enum-types.h
(no output)
```