### PR TITLE
[nm-applet] depend on networkmanager of >=M.m version

### DIFF
--- a/gnome-extra/nm-applet/nm-applet-1.8.0.ebuild
+++ b/gnome-extra/nm-applet/nm-applet-1.8.0.ebuild
@@ -6,7 +6,7 @@ GNOME2_EAUTORECONF="yes"
 GNOME2_LA_PUNT="yes"
 GNOME_ORG_MODULE="network-manager-applet"
 
-inherit gnome2
+inherit gnome2 versionator
 
 DESCRIPTION="GNOME applet for NetworkManager"
 HOMEPAGE="https://wiki.gnome.org/Projects/NetworkManager"
@@ -26,7 +26,7 @@ RDEPEND="
 	>=x11-libs/libnotify-0.7.0
 
 	app-text/iso-codes
-	>=net-misc/networkmanager-1.3:=[introspection?,modemmanager?,teamd?]
+	>=net-misc/networkmanager-$(get_version_component_range 1-2):=[introspection?,modemmanager?,teamd?]
 	net-misc/mobile-broadband-provider-info
 
 	introspection? ( >=dev-libs/gobject-introspection-0.9.6:= )


### PR DESCRIPTION
This change causes the networkmanager dep to at least match the ebuild's `major.minor` version.

nm-applet is from the networkmanager repo AFAIK, and so relies on networkmanager of at least the same version, maybe.