### PR TITLE
[nm-applet] depend on >=networkmanager-1.7

### DIFF
--- a/gnome-extra/nm-applet/nm-applet-1.8.0.ebuild
+++ b/gnome-extra/nm-applet/nm-applet-1.8.0.ebuild
@@ -26,7 +26,7 @@ RDEPEND="
 	>=x11-libs/libnotify-0.7.0
 
 	app-text/iso-codes
-	>=net-misc/networkmanager-1.3:=[introspection?,modemmanager?,teamd?]
+	>=net-misc/networkmanager-1.7:=[introspection?,modemmanager?,teamd?]
 	net-misc/mobile-broadband-provider-info
 
 	introspection? ( >=dev-libs/gobject-introspection-0.9.6:= )


### PR DESCRIPTION
```
...
checking for LIBNM_GLIB... no
configure: error: in `/var/tmp/portage/gnome-extra/nm-applet-1.8.0/work/network-manager-applet-1.8.0':
configure: error: Requested 'NetworkManager >= 1.7' but version of NetworkManager is 1.6.2
Requested 'libnm-glib >= 1.7' but version of libnm-glib is 1.6.2
Requested 'libnm-util >= 1.7' but version of libnm-util is 1.6.2
Requested 'libnm-glib-vpn >= 1.7' but version of libnm-glib-vpn is 1.6.2
...
```