### PR TITLE
dev-python/pygobject: fix required pycairo dependency version

### DIFF
--- a/dev-python/pygobject/pygobject-3.26.0.ebuild
+++ b/dev-python/pygobject/pygobject-3.26.0.ebuild
@@ -25,7 +25,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	>=dev-libs/gobject-introspection-1.46.0:=
 	virtual/libffi:=
 	cairo? (
-		>=dev-python/pycairo-1.10.0[${PYTHON_USEDEP}]
+		>=dev-python/pycairo-1.11.1[${PYTHON_USEDEP}]
 		x11-libs/cairo )
 "
 DEPEND="${COMMON_DEPEND}


### PR DESCRIPTION
new version required:
m4_define(pycairo_required_version, 1.11.1)