### PR TITLE
gnome-extra/gnome-calendar: add libdazzle dependency

### DIFF
--- a/gnome-extra/gnome-calendar/gnome-calendar-3.27.2.ebuild
+++ b/gnome-extra/gnome-calendar/gnome-calendar-3.27.2.ebuild
@@ -20,6 +20,7 @@ RDEPEND="
 	>=gnome-extra/evolution-data-server-3.17.1:=
 	>=net-libs/gnome-online-accounts-3.2.0:=
 	>=x11-libs/gtk+-3.21.6:3
+	>=dev-libs/libdazzle-3.27.1
 "
 DEPEND="${RDEPEND}
 	dev-libs/appstream-glib


### PR DESCRIPTION
Signed-off-by: David Heidelberg <david@ixit.cz>