### PR TITLE
Move gnome2-live eclass to https

### DIFF
--- a/eclass/gnome2-live.eclass
+++ b/eclass/gnome2-live.eclass
@@ -53,7 +53,7 @@ ELTCONF=${ELTCONF:-}
 # @ECLASS-VARIABLE: EGIT_REPO_URI
 # @DESCRIPTION:
 # git URI for the project, uses GNOME_LIVE_MODULE by default
-: "${EGIT_REPO_URI:="git://git.gnome.org/${GNOME_LIVE_MODULE}"}"
+: "${EGIT_REPO_URI:="https://git.gnome.org/browse/${GNOME_LIVE_MODULE}"}"
 
 # @ECLASS-VARIABLE: PATCHES
 # @DESCRIPTION:


### PR DESCRIPTION
As for now git-r3 diswants to fetch from 'git://' urls, each time warning about necessarity to use https instead.