### PR TITLE
add ruby25 to webkit-gtk

### DIFF
--- a/net-libs/webkit-gtk/webkit-gtk-2.19.3.ebuild
+++ b/net-libs/webkit-gtk/webkit-gtk-2.19.3.ebuild
@@ -4,7 +4,7 @@
 EAPI=6
 CMAKE_MAKEFILE_GENERATOR="ninja"
 PYTHON_COMPAT=( python2_7 )
-USE_RUBY="ruby22 ruby23 ruby24"
+USE_RUBY="ruby22 ruby23 ruby24 ruby25"
 
 inherit check-reqs cmake-utils eutils flag-o-matic gnome2 pax-utils python-any-r1 ruby-single toolchain-funcs versionator virtualx
 

--- a/net-libs/webkit-gtk/webkit-gtk-2.4.11-r300.ebuild
+++ b/net-libs/webkit-gtk/webkit-gtk-2.4.11-r300.ebuild
@@ -3,7 +3,7 @@
 
 EAPI="6"
 PYTHON_COMPAT=( python2_7 )
-USE_RUBY="ruby20 ruby21 ruby22 ruby23 ruby24"
+USE_RUBY="ruby20 ruby21 ruby22 ruby23 ruby24 ruby25"
 
 inherit autotools check-reqs flag-o-matic gnome2 pax-utils python-any-r1 ruby-single toolchain-funcs versionator virtualx
 


### PR DESCRIPTION
I've switched to ruby25, this caused me to pull ruby24 back in deps.