### PR TITLE
add vala to dconf's build dependency

### DIFF
--- a/gnome-base/dconf/dconf-0.27.1.ebuild
+++ b/gnome-base/dconf/dconf-0.27.1.ebuild
@@ -23,6 +23,7 @@ DEPEND="${RDEPEND}
 	>=dev-util/gtk-doc-am-1.15
 	sys-devel/gettext
 	virtual/pkgconfig
+	>=dev-lang/vala-0.39.4
 "
 
 src_install() {


### PR DESCRIPTION
dconf's compilition needs vala's command valac,or there will be an error occurs.