### PR TITLE
gnome-keyring: fix version of gcr dependency

### DIFF
--- a/gnome-base/gnome-keyring/gnome-keyring-3.28.0.1.ebuild
+++ b/gnome-base/gnome-keyring/gnome-keyring-3.28.0.1.ebuild
@@ -17,7 +17,7 @@ KEYWORDS="alpha amd64 arm ~arm64 ia64 ~mips ppc ppc64 ~sh sparc x86 ~amd64-fbsd 
 
 # Replace gkd gpg-agent with pinentry[gnome-keyring] one, bug #547456
 RDEPEND="
-	>=app-crypt/gcr-3.5.3:=[gtk]
+	>=app-crypt/gcr-3.27.90:=[gtk]
 	>=dev-libs/glib-2.38:2
 	app-misc/ca-certificates
 	>=dev-libs/libgcrypt-1.2.2:0=


### PR DESCRIPTION
I got this configure error:
```
configure: error: Package requirements (gcr-3 >= 3.27.90) were not met
```