### PR TITLE
gnome-shell: fix mutter version constraint

### DIFF
--- a/gnome-base/gnome-shell/gnome-shell-3.28.0.ebuild
+++ b/gnome-base/gnome-shell/gnome-shell-3.28.0.ebuild
@@ -44,7 +44,7 @@ COMMON_DEPEND="
 	>=sys-auth/polkit-0.100[introspection]
 	>=x11-libs/libXfixes-5.0
 	x11-libs/libXtst
-	>=x11-wm/mutter-3.25.90[introspection]
+	>=x11-wm/mutter-3.28.0[introspection]
 	>=x11-libs/startup-notification-0.11
 	dev-lang/sassc
 


### PR DESCRIPTION
Without that version constraint you could run into:

```
Native dependency 'mutter-clutter-2' not found
```

if e.g. your mutter version is too old.