### PR TITLE
gnome-base/gvfs: add avahi dependency and useflag

### DIFF
--- a/gnome-base/gvfs/gvfs-1.37.1-r1.ebuild
+++ b/gnome-base/gvfs/gvfs-1.37.1-r1.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://wiki.gnome.org/Projects/gvfs"
 LICENSE="LGPL-2+"
 SLOT="0"
 
-IUSE="afp archive bluray cdda fuse google gnome-keyring gnome-online-accounts gphoto2 +http ios nfs policykit systemd test +udev udisks zeroconf samba +mtp"
+IUSE="afp avahi archive bluray cdda fuse google gnome-keyring gnome-online-accounts gphoto2 +http ios nfs policykit systemd test +udev udisks zeroconf samba +mtp"
 REQUIRED_USE="
 	cdda? ( udev )
 	google? ( gnome-online-accounts )
@@ -29,6 +29,7 @@ RDEPEND="
 	dev-libs/libxml2:2
 	net-misc/openssh
 	afp? ( >=dev-libs/libgcrypt-1.2.2:0= )
+	avahi? ( net-dns/avahi )
 	archive? ( app-arch/libarchive:= )
 	bluray? ( media-libs/libbluray )
 	fuse? ( >=sys-fs/fuse-2.8.0 )
@@ -106,6 +107,7 @@ src_configure() {
 		$(meson_use archive)
 		$(meson_use bluray)
 		$(meson_use cdda)
+		$(meson_use avahi dnssd)
 		$(meson_use fuse)
 		$(meson_use gnome-online-accounts goa)
 		$(meson_use gnome-keyring keyring)


### PR DESCRIPTION
adding avahi dependency, fixes build if it is not installed