### PR TITLE
add mozjs52 ("spidermonkey") dependency

### DIFF
--- a/sys-auth/polkit/polkit-0.114.ebuild
+++ b/sys-auth/polkit/polkit-0.114.ebuild
@@ -31,6 +31,7 @@ CDEPEND="
 DEPEND="${CDEPEND}
 	app-text/docbook-xml-dtd:4.1.2
 	app-text/docbook-xsl-stylesheets
+	=dev-lang/spidermonkey-52*
 	dev-libs/gobject-introspection-common
 	dev-libs/libxslt
 	dev-util/gtk-doc-am


### PR DESCRIPTION
to address the error:
"configure: error: Package requirements (mozjs-52) were not met:
No package 'mozjs-52' found"