### PR TITLE
remove outdated dependencies

### DIFF
--- a/sys-auth/polkit/polkit-0.114.ebuild
+++ b/sys-auth/polkit/polkit-0.114.ebuild
@@ -17,7 +17,6 @@ IUSE="elogind examples gtk +introspection jit kde nls pam selinux systemd test"
 REQUIRED_USE="?? ( elogind systemd )"
 
 CDEPEND="
-	dev-lang/spidermonkey:0/mozjs185[-debug]
 	dev-libs/glib:2
 	dev-libs/expat
 	elogind? ( sys-auth/elogind )

--- a/sys-auth/polkit/polkit-0.114.ebuild
+++ b/sys-auth/polkit/polkit-0.114.ebuild
@@ -20,7 +20,6 @@ CDEPEND="
 	dev-libs/glib:2
 	dev-libs/expat
 	elogind? ( sys-auth/elogind )
-	introspection? ( dev-libs/gobject-introspection )
 	pam? (
 		sys-auth/pambase
 		virtual/pam

--- a/sys-auth/polkit/polkit-0.114.ebuild
+++ b/sys-auth/polkit/polkit-0.114.ebuild
@@ -93,7 +93,6 @@ src_configure() {
 		--enable-man-pages \
 		--disable-gtk-doc \
 		--disable-examples \
-		--with-mozjs=mozjs185 \
 		$(use_enable elogind libelogind) \
 		$(use_enable introspection) \
 		$(use_enable nls) \


### PR DESCRIPTION
i imagine this is all that needs doing? as the ebuild clearly doesn't try to force an archaic version of spidermonkey i'm guessing that the econf line was deprecated a while back presumably. either way i've left edits on so if you want to try just changing --with-mozjs to mozjs52 you can try that. i also removed the gobject-introspection depend, because that package already depends on gobject-introspection-common (so it would already get pulled in?)