### PR TITLE
add meson dependency

### DIFF
--- a/net-libs/glib-networking/glib-networking-2.57.2.ebuild
+++ b/net-libs/glib-networking/glib-networking-2.57.2.ebuild
@@ -29,6 +29,7 @@ RDEPEND="
 DEPEND="${RDEPEND}
 	>=sys-devel/gettext-0.19.4
 	>=virtual/pkgconfig-0-r1[${MULTILIB_USEDEP}]
+	>=dev-util/meson-0.46.0
 	test? ( sys-apps/dbus[X] )
 "
 # eautoreconf needs >=sys-devel/autoconf-2.65:2.5


### PR DESCRIPTION
build fails without at least this version
