### PR TITLE
make simple-scan depend on colord with vala USE flag

### DIFF
--- a/media-gfx/simple-scan/simple-scan-3.30.0.ebuild
+++ b/media-gfx/simple-scan/simple-scan-3.30.0.ebuild
@@ -22,7 +22,7 @@ COMMON_DEPEND="
 	virtual/jpeg:0=
 	x11-libs/cairo:=
 	>=x11-libs/gtk+-3:3
-	colord? ( >=x11-misc/colord-0.1.24:=[udev] )
+	colord? ( >=x11-misc/colord-0.1.24:=[udev,vala] )
 "
 # packagekit? ( app-admin/packagekit-base )
 RDEPEND="${COMMON_DEPEND}


### PR DESCRIPTION
Compilation fails if `colord` was compiled without the vala USE flag.