### PR TITLE
libsoup: Fix ntlm_auth option behind USE=samba

### DIFF
--- a/net-libs/libsoup/libsoup-2.65.90.ebuild
+++ b/net-libs/libsoup/libsoup-2.65.90.ebuild
@@ -46,13 +46,12 @@ src_prepare() {
 }
 
 src_configure() {
-	#TODO:
-	#$(meson_use samba ntlm)
-	#$(usex samba -Dntlm-auth="${EPREFIX}"/usr/bin/ntlm_auth "")
 	local emesonargs=(
 		$(meson_use gssapi)
-		$(meson_use introspection)	
+		$(meson_use introspection)
+		$(meson_use samba ntlm)
 		$(meson_use vala vapi)
+		$(usex samba -Dntlm_auth="'${EPREFIX}/usr/bin/ntlm_auth'" "")
 	)
 	meson_src_configure
 }


### PR DESCRIPTION
It wants underscore and quotes, otherwise it takes a fallback value from
meson_options.txt and/or expands the macro in code to raw characters
like a variable name instead of a string.