### PR TITLE
Update evolution-3.31.91.ebuild

### DIFF
--- a/mail-client/evolution/evolution-3.31.91.ebuild
+++ b/mail-client/evolution/evolution-3.31.91.ebuild
@@ -103,6 +103,7 @@ src_configure() {
 		-DENABLE_YTNEF=OFF
 		-DENABLE_PST_IMPORT=OFF
 		-DENABLE_GTKSPELL=$(usex spell ON OFF)
+		-DENABLE_WEATHER=$(usex weather ON OFF)
 	)
 	cmake-utils_src_configure
 }


### PR DESCRIPTION
Having issues with underlying libraries for weather support, but ebuild didn't support all cmake config option, so added one more.