### PR TITLE
gjs: use slot dep on spidermonkey

### DIFF
--- a/dev-libs/gjs/gjs-1.56.0.ebuild
+++ b/dev-libs/gjs/gjs-1.56.0.ebuild
@@ -18,7 +18,7 @@ RDEPEND="
 	>=dev-libs/gobject-introspection-1.41.4:=
 
 	sys-libs/readline:0
-	=dev-lang/spidermonkey-60.1.0:60
+	dev-lang/spidermonkey:60
 	virtual/libffi
 	cairo? ( x11-libs/cairo[X] )
 	gtk? ( x11-libs/gtk+:3 )


### PR DESCRIPTION
gjs can use spidermonkey-60.5.2_p0-r1 in gentoo tree. After updating spidermonkey gjs must be rebuilt or it/gnome-shell segfaults. I don't know how to enforce the rebuild, but can confirm it works with the in tree version.