### PR TITLE
control-center, settings-daemon: add cups and colord use flag for compat

### DIFF
--- a/gnome-base/gnome-control-center/gnome-control-center-3.32.0.1.ebuild
+++ b/gnome-base/gnome-control-center/gnome-control-center-3.32.0.1.ebuild
@@ -11,7 +11,7 @@ HOMEPAGE="https://git.gnome.org/browse/gnome-control-center/"
 
 LICENSE="GPL-2+"
 SLOT="2"
-IUSE="+i18n v4l wayland"
+IUSE="+cups +i18n v4l wayland"
 KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sh ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~x86-solaris"
 
 # False positives caused by nested configure scripts

--- a/gnome-base/gnome-settings-daemon/gnome-settings-daemon-3.32.0.ebuild
+++ b/gnome-base/gnome-settings-daemon/gnome-settings-daemon-3.32.0.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://git.gnome.org/browse/gnome-settings-daemon"
 
 LICENSE="GPL-2+"
 SLOT="0"
-IUSE="+cups debug +networkmanager policykit -smartcard test +udev wayland"
+IUSE="+colord +cups debug +networkmanager policykit -smartcard test +udev wayland"
 REQUIRED_USE="udev"
 KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~x86-solaris"
 


### PR DESCRIPTION
Dependencies of gnome-core-apps and gnome-extra-apps require cups or colord use flags set. gnome-control-center and gnome-settings-daemon dropped these flags in this overlay as they are now unconditionally required, however this breaks the dependency calculation. I suggest to just re-add the use flags without any real purpose to simplify the dependency calculation with the ebuilds from the overlay.