### PR TITLE
x11-libs/gtksourceview:4: correctly set meson args

### DIFF
--- a/x11-libs/gtksourceview/gtksourceview-4.3.1.ebuild
+++ b/x11-libs/gtksourceview/gtksourceview-4.3.1.ebuild
@@ -38,6 +38,15 @@ src_prepare() {
 	gnome2_src_prepare
 }
 
+src_configure() {
+	local emesonargs=(
+		-Dglade_catalog=$(usex glade true false)
+		-Dgir=$(usex introspection true false)
+		-Dvapi=$(usex vala true false)
+	)
+	meson_src_configure
+}
+
 src_install() {
 	meson_src_install
 


### PR DESCRIPTION
Otherwise build fails, when Vala USE is disabled.

Signed-off-by: David Heidelberg <david@ixit.cz>