### PR TITLE
gnome-base/librsvg: dev-lang/rust is a build time dependency

### DIFF
--- a/gnome-base/librsvg/librsvg-2.45.90.ebuild
+++ b/gnome-base/librsvg/librsvg-2.45.90.ebuild
@@ -25,11 +25,11 @@ RDEPEND="
 	>=dev-libs/libxml2-2.9.1-r4:2[${MULTILIB_USEDEP}]
 	>=dev-libs/libcroco-0.6.8-r1[${MULTILIB_USEDEP}]
 	>=x11-libs/gdk-pixbuf-2.30.7:2[introspection?,${MULTILIB_USEDEP}]
-	>=dev-lang/rust-1.31.1[${MULTILIB_USEDEP}]
 	introspection? ( >=dev-libs/gobject-introspection-0.10.8:= )
 	tools? ( >=x11-libs/gtk+-3.10.0:3 )
 "
 DEPEND="${RDEPEND}
+	>=dev-lang/rust-1.31.1[${MULTILIB_USEDEP}]
 	dev-libs/gobject-introspection-common
 	dev-libs/vala-common
 	>=dev-util/gtk-doc-am-1.13


### PR DESCRIPTION
this is actually important for cross compile with emerge wrappers from crossdev. 