### PR TITLE
gnome-base/librsvg: --without-gtk3 is gone

### DIFF
--- a/gnome-base/librsvg/librsvg-2.45.90.ebuild
+++ b/gnome-base/librsvg/librsvg-2.45.90.ebuild
@@ -80,7 +80,6 @@ multilib_src_configure() {
 		--disable-static \
 		--disable-tools \
 		$(multilib_native_use_enable introspection) \
-		$(multilib_native_use_with tools gtk3) \
 		$(multilib_native_use_enable vala) \
 		--enable-pixbuf-loader \
 		"${myconf[@]}"


### PR DESCRIPTION
it seems to have been possible to prefere gtk2 over gtk3 in the past, but that's no more. 