### PR TITLE
gnome-base/librsvg: pull in rust-std-bin along with rust-bin

### DIFF
--- a/gnome-base/librsvg/librsvg-2.45.92.ebuild
+++ b/gnome-base/librsvg/librsvg-2.45.92.ebuild
@@ -29,7 +29,10 @@ RDEPEND="
 	tools? ( >=x11-libs/gtk+-3.10.0:3 )
 "
 DEPEND="${RDEPEND}
-	>=dev-lang/rust-1.34.2[${MULTILIB_USEDEP}]
+	|| (	
+		>=dev-lang/rust-1.34.2[${MULTILIB_USEDEP}]
+		( >=dev-lang/rust-bin-1.34.2[${MULTILIB_USEDEP}] >=dev-lang/rust-std-bin-1.34.2[${MULTILIB_USEDEP}] )
+	)
 	dev-libs/gobject-introspection-common
 	dev-libs/vala-common
 	>=dev-util/gtk-doc-am-1.13


### PR DESCRIPTION
librsvg expects a full i686-unknown-linux-gnu std to be available to allow multilib compile with rust-bin 

it seems to pull in all the correct options. But please somebody test this, I don't use librsvg with multilib on my own! @jrevillard 

```
USE="abi_x86_32"  emerge -pv =librsvg-2.45.92::gnome-next

These are the packages that would be merged, in order:

Calculating dependencies... done!
[ebuild   R    ] dev-libs/lzo-2.10:2::gentoo  USE="(split-usr) static-libs -examples" ABI_X86="32* (64) (-x32)" 0 KiB
[ebuild   R   ~] dev-lang/rust-bin-1.37.0:stable::gentoo  USE="rustfmt -clippy -doc -libressl" ABI_X86="32* (64) (-x32)" CPU_FLAGS_X86="sse2" 0 KiB
[ebuild  N    ~] dev-lang/rust-std-bin-1.37.0:stable::gnome-next  ABI_X86="32" CPU_FLAGS_X86="sse2" 0 KiB
[ebuild   R    ] x11-libs/pixman-0.38.4::gentoo  USE="(-altivec) (-loongson2f) (-neon)" ABI_X86="32* (64) (-x32)" CPU_FLAGS_X86="mmxext sse2 ssse3" 0 KiB
[ebuild   R    ] dev-libs/fribidi-1.0.5::gentoo  USE="-static-libs" ABI_X86="32* (64) (-x32)" 0 KiB
[ebuild   R    ] dev-libs/libcroco-0.6.13:0.6::gentoo  USE="-test" ABI_X86="32* (64) (-x32)" 0 KiB
[ebuild   R    ] x11-libs/libXft-2.3.3::gentoo  USE="-doc -static-libs" ABI_X86="32* (64) (-x32)" 0 KiB
[ebuild   R    ] x11-libs/gdk-pixbuf-2.38.1:2::gentoo  USE="X introspection jpeg tiff -gtk-doc" ABI_X86="32* (64) (-x32)" 0 KiB
[ebuild   R    ] sys-libs/binutils-libs-2.32-r1:0/2.32::gentoo  USE="nls -64-bit-bfd -multitarget -static-libs" ABI_X86="32* (64) (-x32)" 0 KiB
[ebuild   R    ] x11-libs/cairo-1.16.0-r3::gentoo  USE="X glib opengl svg xcb (-aqua) -debug (-gles2) -static-libs -utils -valgrind" ABI_X86="32* (64) (-x32)" 0 KiB
[ebuild   R    ] media-gfx/graphite2-1.3.13::gentoo  USE="-perl -test" ABI_X86="32* (64) (-x32)" 0 KiB
[ebuild   R    ] media-libs/harfbuzz-2.6.1:0/0.9.18::gentoo  USE="cairo glib graphite icu truetype -debug -introspection -static-libs -test" ABI_X86="32* (64) (-x32)" 0 KiB
[ebuild   R    ] x11-libs/pango-1.42.4-r2::gentoo  USE="X introspection -test" ABI_X86="32* (64) (-x32)" 0 KiB
[ebuild     U ~] gnome-base/librsvg-2.45.92:2::gnome-next [2.40.20:2::gentoo] USE="-gtk-doc% -introspection* -tools -vala*" ABI_X86="32* (64) (-x32)" 0 KiB

Total: 14 packages (1 upgrade, 1 new, 12 reinstalls), Size of downloads: 0 KiB
```