### PR TITLE
gnome-base/librsvg: copy over stable keywords from older 2.45.90

### DIFF
--- a/gnome-base/librsvg/librsvg-2.45.92.ebuild
+++ b/gnome-base/librsvg/librsvg-2.45.92.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://wiki.gnome.org/Projects/LibRsvg"
 
 LICENSE="LGPL-2"
 SLOT="2"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 ~s390 ~sh ~sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
 
 IUSE="gtk-doc +introspection tools vala"
 REQUIRED_USE="vala? ( introspection )"


### PR DESCRIPTION
should be fine. 