### PR TITLE
app-crypt/gcr: add patch to fix cross-compile

### DIFF
--- a/app-crypt/gcr/files/gcr-3.28.1-fix-cross-compile.patch
+++ b/app-crypt/gcr/files/gcr-3.28.1-fix-cross-compile.patch
@@ -1,0 +1,32 @@
+From 1479bda8d36ed7b167a003e016b426ae615c6f33 Mon Sep 17 00:00:00 2001
+From: Simon McVittie <smcv@debian.org>
+Date: Wed, 25 Sep 2019 10:08:25 +0100
+Subject: [PATCH 1/2] configure: Use PKG_PROG_PKG_CONFIG instead of reinventing
+ it
+
+When cross-compiling (for example for aarch64 on x86), using AC_PATH_PROG
+to search for pkg-config will find the build architecture (x86)
+pkg-config, but what we want is the host architecture (aarch64)
+pkg-config. PKG_PROG_PKG_CONFIG does this correctly, by using
+AC_PATH_TOOL.
+
+Signed-off-by: Simon McVittie <smcv@debian.org>
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 81ac2fb..17131ee 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -71,7 +71,7 @@ AC_PROG_LN_S
+ AM_DISABLE_STATIC
+ AM_PROG_LIBTOOL
+ IT_PROG_INTLTOOL([0.35.0])
+-AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
++PKG_PROG_PKG_CONFIG
+ 
+ GETTEXT_PACKAGE=gcr
+ AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE,"$GETTEXT_PACKAGE", [The gettext domain name])
+-- 
+2.22.0

--- a/app-crypt/gcr/gcr-3.28.1.ebuild
+++ b/app-crypt/gcr/gcr-3.28.1.ebuild
@@ -51,6 +51,8 @@ pkg_setup() {
 }
 
 src_prepare() {
+	PATCHES=( "${FILESDIR}"/gcr-3.28.1-fix-cross-compile.patch )
+
 	# Disable stupid flag changes
 	sed -e 's/CFLAGS="$CFLAGS -g"//' \
 		-e 's/CFLAGS="$CFLAGS -O0"//' \


### PR DESCRIPTION
cherry picked from upstream: https://gitlab.gnome.org/GNOME/gcr/commit/a26b7a28392ec0d30b25791dcd7dc2ddd95bc1dc

does this need to run `eautoconf` in `src_prepare` after patching? 