### PR TITLE
gnome-base/*: migrate to sys-libs/pam

### DIFF
--- a/gnome-base/gdm/gdm-3.34.1.ebuild
+++ b/gnome-base/gdm/gdm-3.34.1.ebuild
@@ -51,8 +51,7 @@ COMMON_DEPEND="
 	x11-libs/libxcb
 	>=x11-misc/xdg-utils-1.0.2-r3
 
-	virtual/pam
-
+	sys-libs/pam
 	>=sys-apps/systemd-186:0=[pam]
 
 	sys-auth/pambase[systemd]

--- a/gnome-base/gnome-keyring/gnome-keyring-3.34.0.ebuild
+++ b/gnome-base/gnome-keyring/gnome-keyring-3.34.0.ebuild
@@ -22,7 +22,7 @@ RDEPEND="
 	app-misc/ca-certificates
 	>=dev-libs/libgcrypt-1.2.2:0=
 	caps? ( sys-libs/libcap-ng )
-	pam? ( virtual/pam )
+	pam? ( sys-libs/pam )
 	selinux? ( sec-policy/selinux-gnome )
 	>=app-crypt/gnupg-2.0.28:=
 	ssh-agent? ( net-misc/openssh )


### PR DESCRIPTION
Please merge ASAP, virtual/pam is already masked in gx86

Signed-off-by: David Heidelberg <david@ixit.cz>