### PR TITLE
gnome-extra/sushi: workaround sandbox violation

### DIFF
--- a/gnome-extra/sushi/sushi-3.34.0.ebuild
+++ b/gnome-extra/sushi/sushi-3.34.0.ebuild
@@ -42,3 +42,11 @@ RDEPEND="${COMMON_DEPEND}
 	>=gnome-base/nautilus-3.1.90
 	office? ( app-office/libreoffice )
 "
+
+src_compile() {
+       addpredict /dev/dri/renderD128
+       addpredict /dev/dri/card0
+
+       default
+}
+


### PR DESCRIPTION
Closes: https://github.com/Heather/gentoo-gnome/issues/328

Signed-off-by: David Heidelberg <david@ixit.cz>