### PR TITLE
gnome-base/librsvg: raise minimal rust dep to 1.36.0

### DIFF
--- a/gnome-base/librsvg/librsvg-2.47.1.ebuild
+++ b/gnome-base/librsvg/librsvg-2.47.1.ebuild
@@ -29,8 +29,8 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}
 	|| (	
-		>=dev-lang/rust-1.34.2[${MULTILIB_USEDEP}]
-		( >=dev-lang/rust-bin-1.34.2[${MULTILIB_USEDEP}] >=dev-lang/rust-std-bin-1.34.2[${MULTILIB_USEDEP}] )
+		>=dev-lang/rust-1.36.0[${MULTILIB_USEDEP}]
+		( >=dev-lang/rust-bin-1.36.0[${MULTILIB_USEDEP}] >=dev-lang/rust-std-bin-1.36.0[${MULTILIB_USEDEP}] )
 	)
 	dev-libs/gobject-introspection-common
 	dev-libs/vala-common


### PR DESCRIPTION
upstream demands so in compile.md