### PR TITLE
gnome-extra/evolution-data-server: fix dependency on ical

### DIFF
--- a/gnome-extra/evolution-data-server/evolution-data-server-3.34.2.ebuild
+++ b/gnome-extra/evolution-data-server/evolution-data-server-3.34.2.ebuild
@@ -18,7 +18,7 @@ SLOT="0/59" # subslot = libcamel-1.2 soname version
 IUSE="api-doc-extras berkdb +gnome-online-accounts +gtk google +introspection ipv6 ldap kerberos vala +weather"
 REQUIRED_USE="vala? ( introspection )"
 
-KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~x86-solaris"
 
 # sys-libs/db is only required for migrating from <3.13 versions
 # gdata-0.17.7 soft required for new gdata_feed_get_next_page_token API to handle more than 100 google tasks
@@ -29,7 +29,7 @@ RDEPEND="
 	>=app-crypt/libsecret-0.5[crypt]
 	>=dev-db/sqlite-3.7.17:=
 	>=dev-libs/glib-2.53.4:2
-	>=dev-libs/libical-3.0.5:=[introspection,glib,vala?]
+	>=dev-libs/libical-3.0.6:=[introspection,vala?]
 	>=dev-libs/libxml2-2
 	>=dev-libs/nspr-4.4:=
 	>=dev-libs/nss-3.9:=


### PR DESCRIPTION
Since commit 1c6e0593af245703205da5109eb46721cc0e542a is glib merged
into introspection USE flag.

Signed-off-by: David Heidelberg <david@ixit.cz>