### PR TITLE
gnome-base/librsvg: remove virtual/cargo

### DIFF
--- a/gnome-base/librsvg/librsvg-2.47.2.ebuild
+++ b/gnome-base/librsvg/librsvg-2.47.2.ebuild
@@ -36,7 +36,6 @@ DEPEND="${RDEPEND}
 	dev-libs/vala-common
 	>=dev-util/gtk-doc-am-1.13
 	>=virtual/pkgconfig-0-r1[${MULTILIB_USEDEP}]
-	virtual/cargo
 	gtk-doc? ( >=dev-util/gtk-doc-1.13 )
 	vala? ( $(vala_depend) )
 "


### PR DESCRIPTION
virtual/cargo is going away, see https://bugs.gentoo.org/695698