### PR TITLE
dev-util/gtk-doc: add missing pygments for building gtk-doc

### DIFF
--- a/dev-util/gtk-doc/gtk-doc-1.30.ebuild
+++ b/dev-util/gtk-doc/gtk-doc-1.30.ebuild
@@ -31,6 +31,7 @@ RDEPEND="
 		vim? ( || ( app-editors/vim app-editors/gvim ) )
 		!vim? ( dev-util/source-highlight )
 	)
+	dev-python/pygments[${PYTHON_USEDEP}]
 "
 DEPEND="${RDEPEND}
 	~dev-util/gtk-doc-am-${PV}


### PR DESCRIPTION
otherwise librsvg can't be build with USE="gtk-doc"

