### PR TITLE
dev-util/sysprof: it looks like it isn't installed by sysprof-capture

### DIFF
--- a/dev-util/sysprof/sysprof-3.36.0.ebuild
+++ b/dev-util/sysprof/sysprof-3.36.0.ebuild
@@ -55,8 +55,6 @@ src_configure() {
 
 src_install() {
 	meson_src_install
-	# installed by sysprof-capture, as mutter needs it at build time
-	rm "${ED}"/usr/share/dbus-1/interfaces/org.gnome.Sysprof3.Profiler.xml || die
 }
 
 pkg_postinst() {


### PR DESCRIPTION
Signed-off-by: David Heidelberg <david@ixit.cz>